### PR TITLE
Improve publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
           fi
 
           CURRENT_TAG="v$VERSION"
-          PREVIOUS_TAG=$(git tag --sort=-creatordate | grep -vx "$CURRENT_TAG" || true)
+          PREVIOUS_TAG=$(git tag --sort=-creatordate | grep -Fvx "$CURRENT_TAG" || true)
           PREVIOUS_TAG=$(printf '%s\n' "$PREVIOUS_TAG" | head -n 1)
 
           IS_DRY_RUN="false"
@@ -92,6 +92,16 @@ jobs:
           cargo clippy --all-targets --all-features -- -D warnings
           cargo test --all --all-features
 
+      - name: Publish to crates.io
+        if: needs.check.outputs.is_dry_run != 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+      - name: Dry-run publish
+        if: needs.check.outputs.is_dry_run == 'true'
+        run: cargo publish --dry-run
+
       - name: Create tag and release
         if: needs.check.outputs.is_dry_run != 'true'
         env:
@@ -112,13 +122,3 @@ jobs:
           fi
 
           gh release create "$CURRENT_TAG" --title "$CURRENT_TAG" --target "$GITHUB_SHA" "${NOTES_ARGS[@]}"
-
-      - name: Publish to crates.io
-        if: needs.check.outputs.is_dry_run != 'true'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish
-
-      - name: Dry-run publish
-        if: needs.check.outputs.is_dry_run == 'true'
-        run: cargo publish --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,6 @@
 name: Publish
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -12,18 +10,75 @@ on:
         required: false
         default: false
         type: boolean
+  push:
+    branches: [main]
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  publish:
+  check:
+    if: github.repository == 'ultralytics/template-rust'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      current_tag: ${{ steps.tags.outputs.current_tag }}
+      previous_tag: ${{ steps.tags.outputs.previous_tag }}
+      should_publish: ${{ steps.tags.outputs.should_publish }}
+      is_dry_run: ${{ steps.tags.outputs.is_dry_run }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Determine tags
+        id: tags
+        run: |
+          set -euo pipefail
+
+          VERSION=$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' Cargo.toml | head -n 1)
+          if [ -z "$VERSION" ]; then
+            echo "Version not found in Cargo.toml" >&2
+            exit 1
+          fi
+
+          CURRENT_TAG="v$VERSION"
+          PREVIOUS_TAG=$(git tag --sort=-creatordate | grep -vx "$CURRENT_TAG" || true)
+          PREVIOUS_TAG=$(printf '%s\n' "$PREVIOUS_TAG" | head -n 1)
+
+          IS_DRY_RUN="false"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.dry_run || 'false' }}" = "true" ]; then
+            IS_DRY_RUN="true"
+          fi
+
+          if git rev-parse "$CURRENT_TAG" >/dev/null 2>&1; then
+            SHOULD_PUBLISH="false"
+          else
+            SHOULD_PUBLISH="true"
+          fi
+
+          echo "current_tag=$CURRENT_TAG" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+          echo "should_publish=$SHOULD_PUBLISH" >> "$GITHUB_OUTPUT"
+          echo "is_dry_run=$IS_DRY_RUN" >> "$GITHUB_OUTPUT"
+
+  publish:
+    if: github.repository == 'ultralytics/template-rust' && (needs.check.outputs.should_publish == 'true' || needs.check.outputs.is_dry_run == 'true')
+    needs: check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -37,12 +92,33 @@ jobs:
           cargo clippy --all-targets --all-features -- -D warnings
           cargo test --all --all-features
 
+      - name: Create tag and release
+        if: needs.check.outputs.is_dry_run != 'true'
+        env:
+          CURRENT_TAG: ${{ needs.check.outputs.current_tag }}
+          PREVIOUS_TAG: ${{ needs.check.outputs.previous_tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "UltralyticsAssistant"
+          git config --global user.email "web@ultralytics.com"
+
+          git tag -a "$CURRENT_TAG" -m "$(git log -1 --pretty=%B)"
+          git push origin "$CURRENT_TAG"
+
+          NOTES_ARGS=(--generate-notes)
+          if [ -n "$PREVIOUS_TAG" ]; then
+            NOTES_ARGS+=(--notes-start-tag "$PREVIOUS_TAG")
+          fi
+
+          gh release create "$CURRENT_TAG" --title "$CURRENT_TAG" --target "$GITHUB_SHA" "${NOTES_ARGS[@]}"
+
       - name: Publish to crates.io
+        if: needs.check.outputs.is_dry_run != 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
-            cargo publish --dry-run
-          else
-            cargo publish
-          fi
+        run: cargo publish
+
+      - name: Dry-run publish
+        if: needs.check.outputs.is_dry_run == 'true'
+        run: cargo publish --dry-run


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Automates Rust crate publishing on `main` pushes with smart tag detection, optional dry runs, and automatic GitHub releases. 🚀

### 📊 Key Changes
- 🔁 **Trigger update:** Workflow now runs on `push` to `main` and manual `workflow_dispatch`, instead of only on GitHub Releases.
- 🧪 **New `check` job:** 
  - Reads the crate version from `Cargo.toml` and derives a `vX.Y.Z` tag.
  - Detects the most recent previous tag.
  - Decides whether a publish is needed (skips if the current tag already exists).
  - Determines if this run is a dry run based on `workflow_dispatch` input.
- 📦 **Smarter `publish` job:**
  - Depends on `check` and runs only if a publish is needed or a dry run was requested.
  - Uses `cargo publish` for real publishes and `cargo publish --dry-run` when `dry_run` is true.
- 🏷️ **Automatic tagging and releases:**
  - Creates an annotated Git tag matching the crate version.
  - Pushes the tag back to GitHub.
  - Uses `gh release create` to open a GitHub Release with autogenerated notes, optionally starting from the previous tag.
- 🔐 **Permissions update:** Grants `contents: write` where needed to allow tag creation and release publishing.

### 🎯 Purpose & Impact
- ⚙️ **Fully-automated release flow:** Publishing to crates.io and creating GitHub Releases can now be driven simply by pushing to `main` with an updated version in `Cargo.toml`.
- 🧹 **Reduced manual work & errors:** Eliminates the need to manually create tags and releases, lowering the chance of versioning mistakes.
- 🧪 **Safe testing via dry runs:** Maintainers can validate the entire publish pipeline end-to-end without actually publishing a new crate version.
- 📈 **Consistent versioning:** Ensures crate version, Git tag, and GitHub Release stay in sync, improving traceability for users and contributors.