### PR TITLE
Bump taiki-e/install-action from v2.77.1 to v2.77.2 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+        uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96 # v2.77.2
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.77.1 to v2.77.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov` in CI to a newer patch version for improved reliability and maintenance.

### 📊 Key Changes
- Updated the GitHub Action used for installing `cargo-llvm-cov` in `.github/workflows/ci.yml`
- Changed `taiki-e/install-action` from `v2.77.1` to `v2.77.2`
- Kept the CI workflow behavior the same, with only a small dependency/version refresh 🛠️

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping workflow dependencies up to date ✅
- May provide small fixes or stability improvements in the install step for coverage tooling 📈
- Low-risk change: no application code or Rust logic was modified, so user-facing behavior should remain unchanged 👍