### PR TITLE
Bump taiki-e/install-action from v2.77.5 to v2.77.6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2.77.5
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.77.5 to v2.77.6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov` in CI to a newer `taiki-e/install-action` release.

### 📊 Key Changes
- Bumped the GitHub Action used in `.github/workflows/ci.yml` for installing `cargo-llvm-cov`.
- Updated `taiki-e/install-action` from `v2.77.5` to `v2.77.6`.
- Kept the pinned commit style, which helps maintain reproducible and secure CI runs 🔒

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping dependencies slightly more up to date ⚙️
- May include upstream fixes or small reliability improvements in the install step for coverage tooling 📈
- Low-risk change with minimal user-facing impact, mainly benefiting repository maintainers and CI stability ✅