### PR TITLE
Bump taiki-e/install-action from v2.77.6 to v2.77.7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.77.6 to v2.77.7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by bumping the GitHub Action used to install `cargo-llvm-cov` to a newer patch version.

### 📊 Key Changes
- Updated the **`taiki-e/install-action`** version in `.github/workflows/ci.yml`
  - From `v2.77.6`
  - To `v2.77.7`
- The updated action is used during CI to install **`cargo-llvm-cov`**, the Rust code coverage tool 🦀

### 🎯 Purpose & Impact
- Improves **workflow maintenance** by keeping GitHub Actions dependencies up to date ✅
- May include **minor fixes, stability improvements, or security updates** from the upstream action 🔒
- Has **no direct effect on template functionality or user-facing Rust code**
- Helps keep CI runs more reliable and aligned with current tooling 🚀