### PR TITLE
Bump taiki-e/install-action from v2.77.7 to v2.78.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.77.7 to v2.78.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions dependency used to install `cargo-llvm-cov` in CI, keeping the Rust template’s automation current and reliable.

### 📊 Key Changes
- ⬆️ Updated the GitHub Action `taiki-e/install-action` in `.github/workflows/ci.yml`
- 🔄 Changed the pinned action version from `v2.77.7` to `v2.78.1`
- 🛠️ This action is responsible for installing `cargo-llvm-cov`, which is used for Rust code coverage in CI

### 🎯 Purpose & Impact
- ✅ Keeps CI dependencies up to date with the latest fixes and improvements
- 🔒 Maintains pinned commit usage, which helps preserve workflow security and reproducibility
- 📈 Reduces the risk of issues caused by outdated tooling during coverage checks
- 👩‍💻 For users and contributors, this should be a low-risk maintenance update with no direct changes to template functionality, but it helps keep automated testing healthy and dependable