### PR TITLE
Bump codecov/codecov-action from v6.0.0 to v6.0.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: ./lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Bump codecov/codecov-action from v6.0.0 to v6.0.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions Codecov step in CI from `codecov-action` v6.0.0 to v6.0.1 to keep the Rust template’s automation current and reliable.

### 📊 Key Changes
- ⬆️ Updated the Codecov GitHub Action in `.github/workflows/ci.yml`
- 🔒 Changed the pinned action commit hash to the newer `codecov/codecov-action` release
- 🧪 Kept the existing coverage upload process unchanged, including use of `lcov.info` and `CODECOV_TOKEN`

### 🎯 Purpose & Impact
- ✅ Improves CI maintenance by keeping dependencies up to date
- 🛡️ Helps ensure coverage reporting remains compatible with the latest Codecov action release
- 🔁 Minimizes risk by making a small, targeted infrastructure update without changing project code or test behavior
- 👩‍💻 For users and contributors, this should have little visible effect beyond slightly more reliable CI coverage uploads