### PR TITLE
Bump taiki-e/install-action from v2.79.0 to v2.79.2 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2.79.0
+        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.0 to v2.79.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by bumping the GitHub Action used to install `cargo-llvm-cov` to a newer patch version.

### 📊 Key Changes
- Updated the `Install cargo-llvm-cov` step in [CI workflow](https://github.com/ultralytics/template-rust/blob/main/.github/workflows/ci.yml).
- Changed `taiki-e/install-action` from `v2.79.0` to `v2.79.2`.
- No application code, Rust logic, or project features were modified—this is a GitHub Actions dependency update only. 🛠️

### 🎯 Purpose & Impact
- Helps keep the CI pipeline up to date with the latest fixes in the install action. ✅
- May improve reliability or compatibility when setting up `cargo-llvm-cov` during automated testing and coverage runs. 🚀
- Low-risk change for users and contributors, since it only affects GitHub Actions infrastructure and not runtime behavior. 👍