### PR TITLE
Bump taiki-e/install-action from v2.79.2 to v2.79.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
+        uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.2 to v2.79.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step for installing `cargo-llvm-cov`, bumping the `taiki-e/install-action` dependency from v2.79.2 to v2.79.3 in CI.

### 📊 Key Changes
- Updated the pinned GitHub Action used in `.github/workflows/ci.yml` for installing `cargo-llvm-cov`.
- Changed `taiki-e/install-action` from:
  - `v2.79.2` → `v2.79.3`
- No application code, Rust source files, or user-facing functionality were modified.

### 🎯 Purpose & Impact
- 🛠️ Keeps the CI workflow up to date with the latest patch release of the install action.
- 🔒 Improves maintenance and potentially picks up minor fixes or reliability improvements in dependency installation.
- 🚦 Helps ensure coverage tooling setup in CI remains stable and current.
- 👥 Minimal impact for end users, but beneficial for contributors and maintainers who rely on consistent automated checks.