### PR TITLE
Bump taiki-e/install-action from v2.79.3 to v2.79.4 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
+        uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.3 to v2.79.4 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions dependency used to install `cargo-llvm-cov` in CI, keeping the Rust template’s automation current and reliable.

### 📊 Key Changes
- Updated the GitHub Actions step in `.github/workflows/ci.yml`
- Bumped `taiki-e/install-action` from `v2.79.3` to `v2.79.4`
- Kept the same CI behavior and tool target: installing `cargo-llvm-cov` for coverage reporting

### 🎯 Purpose & Impact
- ✅ Keeps CI dependencies up to date with the latest patch release
- 🛡️ May include minor fixes, compatibility improvements, or security updates from the action maintainer
- 🚀 Helps maintain stable and dependable coverage tooling in automated tests
- 👥 Low-risk change for users and contributors, since it does not alter project code or functionality