### PR TITLE
Bump taiki-e/install-action from v2.79.4 to v2.79.5 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@e0eafa9a0d485c37f97c0f7beb930a58a2facbac # v2.79.4
+        uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.4 to v2.79.5 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions installer used in CI to a newer patch release for `cargo-llvm-cov`, helping keep the Rust template’s automation up to date.

### 📊 Key Changes
- Bumped the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- Updated the action from `v2.79.4` to `v2.79.5`
- The change affects the CI step that installs `cargo-llvm-cov` for Rust code coverage reporting

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping a dependency in the GitHub Actions workflow current 🛠️
- May bring small fixes or reliability improvements from the upstream action update
- Has minimal user-facing impact, but helps make automated testing and coverage workflows more dependable ✅