### PR TITLE
Bump taiki-e/install-action from v2.79.7 to v2.79.8 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4 # v2.79.7
+        uses: taiki-e/install-action@920ab1831fbf4fb3ef75c8ead83556c918bb7290 # v2.79.8
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.7 to v2.79.8 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions setup by bumping the `taiki-e/install-action` version used to install `cargo-llvm-cov` in CI.

### 📊 Key Changes
- Updated the `taiki-e/install-action` GitHub Action in `.github/workflows/ci.yml`
- Changed the pinned action version from `v2.79.7` to `v2.79.8`
- This action is responsible for installing `cargo-llvm-cov`, which is used for Rust code coverage in CI 🧪

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping workflow dependencies up to date 🔄
- May include minor fixes, stability improvements, or security updates from the upstream action 🛡️
- Low-risk change with no direct effect on application code or user-facing functionality
- Helps ensure code coverage tooling continues to work reliably in automated checks ✅