### PR TITLE
Bump taiki-e/install-action from v2.79.8 to v2.79.9 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@920ab1831fbf4fb3ef75c8ead83556c918bb7290 # v2.79.8
+        uses: taiki-e/install-action@8f531eaecd1898bc3da7d104ad91bee98d1b97bd # v2.79.9
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.8 to v2.79.9 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions dependency used to install `cargo-llvm-cov` in CI, keeping the Rust template’s automation current and reliable.

### 📊 Key Changes
- Bumped the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- Updated the pinned GitHub Action from `v2.79.8` to `v2.79.9`
- The change affects the CI step responsible for installing `cargo-llvm-cov` for test coverage runs

### 🎯 Purpose & Impact
- ✅ Keeps the CI workflow up to date with the latest patch release of the install action
- 🛡️ May include minor fixes, security improvements, or stability updates from the action maintainers
- 🚀 Helps maintain reliable coverage tooling setup without changing project code or developer workflows
- 📉 Low-risk change: users should not expect any functional differences outside of slightly improved CI maintainability