### PR TITLE
Bump taiki-e/install-action from v2.79.11 to v2.79.13 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # v2.79.11
+        uses: taiki-e/install-action@15413b256f995d819248ea62704771a959284285 # v2.79.13
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.11 to v2.79.13 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions CI workflow to use a newer version of the `taiki-e/install-action` used for installing `cargo-llvm-cov`.

### 📊 Key Changes
- ⬆️ Bumped the `taiki-e/install-action` version in `.github/workflows/ci.yml`
  - From `v2.79.11`
  - To `v2.79.13`
- 🧪 This action is specifically used to install `cargo-llvm-cov` during CI runs for Rust code coverage.

### 🎯 Purpose & Impact
- 🛠️ Keeps the CI pipeline up to date with the latest patch-level improvements from the upstream GitHub Action.
- 🔒 May include minor fixes, compatibility updates, or security improvements in the install step.
- ✅ Helps maintain reliable automated testing and coverage reporting without changing project code or user-facing functionality.
- 📦 Low-risk maintenance update: most users should see no behavioral changes, but contributors benefit from a slightly more current CI setup.