### PR TITLE
Bump taiki-e/install-action from v2.79.13 to v2.79.15 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@15413b256f995d819248ea62704771a959284285 # v2.79.13
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2 # v2.79.15
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.13 to v2.79.15 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions dependency used to install `cargo-llvm-cov` in CI, keeping the Rust template’s coverage workflow current and reliable.

### 📊 Key Changes
- Updated the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- Bumped the pinned GitHub Action from `v2.79.13` to `v2.79.15`
- The change affects the CI step responsible for installing `cargo-llvm-cov` for test coverage reporting

### 🎯 Purpose & Impact
- Improves 🔒 CI maintenance by keeping workflow dependencies up to date
- Helps ensure ✅ stable and consistent installation of `cargo-llvm-cov` during automated runs
- Reduces the chance of issues caused by older action versions, with minimal risk since this is a small, targeted dependency update
- No user-facing code changes 🚀, but it supports smoother development and testing for contributors