### PR TITLE
Bump taiki-e/install-action from v2.79.15 to v2.80.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2 # v2.79.15
+        uses: taiki-e/install-action@50b4a718b59c718df4ef27a3b445f86cd57b9f00 # v2.80.0
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.79.15 to v2.80.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov` in CI to a newer `taiki-e/install-action` release.

### 📊 Key Changes
- Bumped the GitHub Action used in `.github/workflows/ci.yml` for installing `cargo-llvm-cov`
- Updated `taiki-e/install-action` from `v2.79.15` to `v2.80.0`
- Kept the CI workflow behavior the same, with only the action version changing

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping dependencies up to date 🛠️
- May include upstream fixes, compatibility improvements, or minor reliability enhancements in the install step ✅
- Low-risk change for users and contributors, since it does not alter project code or runtime behavior 📦
- Helps keep the repository’s automation current and secure over time 🔒