### PR TITLE
Bump taiki-e/install-action from v2.80.0 to v2.81.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@50b4a718b59c718df4ef27a3b445f86cd57b9f00 # v2.80.0
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.80.0 to v2.81.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov`, keeping CI dependencies current and improving workflow reliability.

### 📊 Key Changes
- ⬆️ Upgraded the GitHub Action used to install `cargo-llvm-cov` in `.github/workflows/ci.yml`
- 🔄 Changed `taiki-e/install-action` from `v2.80.0` to `v2.81.1`
- 🧪 This affects the CI pipeline step responsible for setting up Rust code coverage tooling

### 🎯 Purpose & Impact
- ✅ Keeps the repository’s CI workflow aligned with the latest upstream action updates
- 🛡️ May improve stability, security, and compatibility in automated test and coverage runs
- 🚀 Helps ensure code coverage setup remains reliable for contributors and maintainers
- 📦 No user-facing feature changes; this is a maintenance update focused on development infrastructure