### PR TITLE
Bump taiki-e/install-action from v2.81.1 to v2.81.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2.81.3
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.1 to v2.81.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov` in CI, bringing the `taiki-e/install-action` dependency to a newer patch version.

### 📊 Key Changes
- Updated the CI workflow file `.github/workflows/ci.yml`.
- Bumped the GitHub Action used for installing `cargo-llvm-cov`:
  - from `taiki-e/install-action` `v2.81.1`
  - to `v2.81.3`
- No application code or Rust template logic was changed—this is a CI maintenance update only. 🛠️

### 🎯 Purpose & Impact
- Improves CI reliability by using a more recent patch release of the install action. ✅
- Helps keep GitHub Actions dependencies up to date for better stability and maintainability. 🔄
- Low risk change: it should not affect end users or the Rust template’s runtime behavior. 📦
- Mainly benefits contributors and maintainers by keeping automated testing and coverage tooling current. 👨‍💻✨