### PR TITLE
Bump astral-sh/setup-uv from v8.1.0 to v8.2.0 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install ultralytics-actions
         run: uv pip install --system --no-cache ultralytics-actions
       - name: Fetch tags


### PR DESCRIPTION
Bump astral-sh/setup-uv from v8.1.0 to v8.2.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Action used to install `uv` in the publishing workflow, moving from `setup-uv` v8.1.0 to v8.2.0.

### 📊 Key Changes
- ⬆️ Bumped the `astral-sh/setup-uv` action in `.github/workflows/publish.yml`
  - From commit `0880764...` (`v8.1.0`)
  - To commit `fac544c...` (`v8.2.0`)
- 🛠️ No application code or Rust template files were changed
- 🔒 The workflow remains pinned to a specific action commit, which helps keep CI/CD builds reproducible and secure

### 🎯 Purpose & Impact
- 🚀 Keeps the publish workflow up to date with the latest improvements and fixes from `setup-uv`
- 🧩 Helps maintain compatibility and reliability in the package publishing process
- 🔐 Preserves good security practice by using a pinned action version instead of an unpinned tag
- 👥 Minimal user-facing impact, but maintainers may benefit from a smoother and more dependable release pipeline