### PR TITLE
Bump taiki-e/install-action from v2.81.5 to v2.81.6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2.81.5
+        uses: taiki-e/install-action@59012be0884e296ca2da49b530610e72c49039ad # v2.81.6
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.5 to v2.81.6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by bumping the `taiki-e/install-action` GitHub Action to a newer patch version for installing `cargo-llvm-cov`.

### 📊 Key Changes
- Updated the GitHub Actions dependency in `.github/workflows/ci.yml`
- Changed `taiki-e/install-action` from `v2.81.5` to `v2.81.6`
- The updated action is still used to install `cargo-llvm-cov` during CI coverage runs

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping workflow dependencies up to date 🛠️
- May include minor fixes, stability improvements, or upstream security updates from the action author
- Low-risk change: it does not affect Rust source code or user-facing functionality
- Helps keep automated testing and coverage workflows reliable over time ✅