### PR TITLE
Bump taiki-e/install-action from v2.81.8 to v2.81.9 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
+        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.8 to v2.81.9 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions installer used in CI to a newer `taiki-e/install-action` version for installing `cargo-llvm-cov`.

### 📊 Key Changes
- ⬆️ Bumped the CI workflow dependency in `.github/workflows/ci.yml`
- 🔄 Updated `taiki-e/install-action` from `v2.81.8` to `v2.81.9`
- 🧪 This action is specifically used to install `cargo-llvm-cov`, which supports Rust code coverage in CI

### 🎯 Purpose & Impact
- 🛠️ Keeps the CI pipeline up to date with the latest patch release of the install action
- 🔒 May bring small reliability, compatibility, or security improvements from the upstream action update
- 🚀 Helps maintain stable automated testing and coverage reporting without changing project code or user-facing behavior
- 👀 Low-risk maintenance change: most users should see no direct effect, but contributors may benefit from smoother CI runs