### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Using the published crate from another project (after release):
 ```toml
 # Cargo.toml
 [dependencies]
-ultralytics-template-rust = "0.0.1"
+ultralytics-template-rust = "0.0.5"
 ```
 
 ```rust


### PR DESCRIPTION
## Summary
- updates the README dependency example to the latest published crate version
- preserves existing badges and community links

## Validation
- git diff --check
- lychee --no-progress --accept 200,429 README.md benches/README.md docs/README.md tests/README.md
- cargo search ultralytics-template-rust --limit 1

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📦 This PR updates the README to reference the latest published crate version, changing `ultralytics-template-rust` from `0.0.1` to `0.0.5`.

### 📊 Key Changes
- Updated the example dependency version in `README.md`
- Replaced:
  - `ultralytics-template-rust = "0.0.1"`
  - with `ultralytics-template-rust = "0.0.5"`
- The change affects the installation/example instructions for users consuming the crate from another Rust project

### 🎯 Purpose & Impact
- Helps users install the current published crate version instead of an outdated one ✅
- Reduces confusion and setup issues when following the README 📘
- Keeps documentation aligned with the actual released package state 🔄
- Improves the first-time user experience for developers trying the Rust template 🚀