### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Using the published crate from another project (after release):
 ```toml
 # Cargo.toml
 [dependencies]
-ultralytics-template-rust = "0.0.5"
+ultralytics-template-rust = "0.0.6"
 ```
 
 ```rust


### PR DESCRIPTION
## Summary
- updates the README dependency example to the newly published crate version 0.0.6
- preserves existing badges and community links

## Validation
- git diff --check
- lychee --no-progress --accept 200,429 README.md benches/README.md docs/README.md tests/README.md
- cargo search ultralytics-template-rust --limit 1

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the README to use `ultralytics-template-rust` version `0.0.6` instead of `0.0.5` in the example dependency snippet.

### 📊 Key Changes
- Updated the `README.md` example for `Cargo.toml` dependencies:
  - Changed `ultralytics-template-rust = "0.0.5"` to `ultralytics-template-rust = "0.0.6"`.
- No source code, API, or functionality changes were introduced in this PR.
- The change is documentation-only 📚

### 🎯 Purpose & Impact
- Helps users install the latest published crate version shown in the documentation ✅
- Reduces confusion caused by outdated setup instructions when starting a new Rust project 🦀
- Improves onboarding by keeping README examples aligned with the current release 📦
- No runtime or behavioral impact for existing users; this mainly benefits new users following the docs 🔧