### PR TITLE
Bump taiki-e/install-action from v2.81.9 to v2.81.10 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@fd2f5e3d644b484055ebf4268f474c565f148f25 # v2.81.9
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.9 to v2.81.10 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions step that installs `cargo-llvm-cov`, keeping CI tooling current with a newer patch release.

### 📊 Key Changes
- Updated the `taiki-e/install-action` version used in `.github/workflows/ci.yml`
- Bumped the pinned GitHub Action from `v2.81.9` to `v2.81.10`
- This change affects the CI step responsible for installing `cargo-llvm-cov` for Rust code coverage checks

### 🎯 Purpose & Impact
- ✅ Keeps the CI workflow up to date with the latest patch-level improvements from the action maintainer
- 🛡️ May improve reliability, compatibility, or security in the code coverage installation step
- 🚀 Low-risk maintenance update with no expected changes to template functionality for end users
- 👨‍💻 Helps maintainers ensure the Rust template’s automated testing and coverage pipeline stays healthy and current