### PR TITLE
Bump taiki-e/install-action from v2.81.11 to v2.82.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.81.11 to v2.82.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions installer used for `cargo-llvm-cov` in CI, keeping the Rust template’s automation current and more reliable.

### 📊 Key Changes
- Updated the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- Bumped the pinned action from `v2.81.11` to `v2.82.0`
- The change affects the CI step that installs `cargo-llvm-cov` for code coverage checks

### 🎯 Purpose & Impact
- Improves ⚙️ CI maintenance by keeping dependencies up to date
- May provide 🛠️ bug fixes, compatibility improvements, or stability enhancements from the newer action release
- Helps ensure 📈 code coverage tooling continues to install and run smoothly in automated workflows
- Low-risk change ✅ with no direct impact on application code or end users, but beneficial for developers maintaining the repository