### PR TITLE
Bump taiki-e/install-action from v2.82.0 to v2.82.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@8b3c737da4b541bf0fb5a3e0488ff20535badac9 # v2.82.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.0 to v2.82.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions setup to use a newer patch version of the `taiki-e/install-action` dependency in CI.

### 📊 Key Changes
- Bumped the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- Updated the action from `v2.82.0` to `v2.82.1`
- This action is used to install `cargo-llvm-cov` during the Rust CI workflow

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping GitHub Actions dependencies up to date 🛠️
- May include small fixes or reliability improvements from the upstream action
- Has no expected impact on template functionality for end users, but helps keep automated testing and coverage workflows stable ✅