### PR TITLE
Bump taiki-e/install-action from v2.82.2 to v2.82.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.2 to v2.82.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by bumping the GitHub Action used to install `cargo-llvm-cov` to a newer patch version.

### 📊 Key Changes
- Updated the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- Changed the pinned action commit from `v2.82.2` to `v2.82.3`
- Kept the CI workflow behavior the same, with no application or Rust source code changes

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping dependencies up to date 🛠️
- May include minor fixes or stability improvements from the newer action release
- Helps ensure the coverage tool installation step remains reliable in GitHub Actions ✅
- Low-risk change: it only affects the CI setup, not the runtime behavior of the Rust template 🚦