### PR TITLE
Bump actions/setup-python from v6.2.0 to v6.3.0 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0


### PR DESCRIPTION
Bump actions/setup-python from v6.2.0 to v6.3.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions Python setup step in the publish workflow to a newer patch release for improved CI maintenance and reliability.

### 📊 Key Changes
- Updated `.github/workflows/publish.yml` to use a newer pinned version of `actions/setup-python`
- Changed the action reference from `v6.2.0` to `v6.3.0`
- Kept the existing workflow behavior the same, including use of Python `3.x`

### 🎯 Purpose & Impact
- Improves workflow maintenance by keeping GitHub Actions dependencies up to date 📦
- May include upstream fixes, stability improvements, or compatibility updates from the `actions/setup-python` release 🚀
- Has minimal user-facing impact, but helps keep the publishing pipeline more reliable and secure 🔒
- Reduces risk of CI issues caused by outdated workflow dependencies 🛠️