### PR TITLE
Bump taiki-e/install-action from v2.82.3 to v2.82.4 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
+        uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2.82.4
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.3 to v2.82.4 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions installer used in CI to a newer patch release for `cargo-llvm-cov`, helping keep the Rust template’s automation current and reliable.

### 📊 Key Changes
- ⬆️ Updated the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- 🛠️ The action change affects the step that installs `cargo-llvm-cov` during CI runs
- 📌 This is a small dependency maintenance update, moving from `v2.82.3` to `v2.82.4`

### 🎯 Purpose & Impact
- ✅ Keeps CI dependencies up to date with the latest patch-level fixes
- 🔒 May improve stability, compatibility, or security of the coverage installation step
- 🚦 Reduces the risk of CI issues caused by outdated GitHub Action versions
- 👥 For users and contributors, the impact is low-risk but beneficial: smoother automated testing and maintenance behind the scenes