### PR TITLE
Bump taiki-e/install-action from v2.82.4 to v2.82.5 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2.82.4
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.4 to v2.82.5 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI maintenance update by bumping the GitHub Action used to install `cargo-llvm-cov` in the Rust template workflow.

### 📊 Key Changes
- Updated the `taiki-e/install-action` version in `.github/workflows/ci.yml`
- The action changed from `v2.82.4` to `v2.82.5`
- This action is used during CI to install `cargo-llvm-cov` for Rust code coverage checks

### 🎯 Purpose & Impact
- Improves 🔒 CI maintenance by keeping GitHub Actions dependencies up to date
- Helps ensure 🧪 code coverage tooling installs reliably in automated workflows
- Likely has minimal user-facing impact, but supports a healthier and more stable development pipeline for contributors 🚀