### PR TITLE
Bump taiki-e/install-action from v2.82.6 to v2.82.7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.6 to v2.82.7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the CI workflow dependency for installing `cargo-llvm-cov` to the latest patch version 🛠️

### 📊 Key Changes
- Bumped `taiki-e/install-action` from `v2.82.6` to `v2.82.7` in the GitHub Actions CI workflow.
- Keeps the action pinned to a specific commit for improved reproducibility and supply-chain security 🔒
- No changes to Rust source code, tests, or project functionality.

### 🎯 Purpose & Impact
- Ensures CI uses the latest patch release of the installer action for `cargo-llvm-cov` 📈
- May include upstream fixes, stability improvements, or maintenance updates for coverage tooling.
- Minimal user-facing impact, but improves the reliability and maintainability of automated test coverage checks ✅