### PR TITLE
Specify Codex CLI for adversarial PR reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ The action hierarchy for every change: **Delete > Replace > Add**. The best code
 After opening a PR:
 
 1. Wait for the automated PR review and auto-format commit from Ultralytics Actions (`format.yml`), then pull and address every finding.
-2. Launch an independent adversarial review agent with cold context (just the PR diff and this file) to hunt for bugs, regressions, and Core Principles violations. Fix, push, and repeat with a fresh agent until one reports LGTM.
+2. Launch an independent adversarial review agent with cold context (just the PR diff and this file) to hunt for bugs, regressions, and Core Principles violations — use the Codex CLI, one fresh `codex exec` run per round. Fix, push, and repeat until a fresh run reports LGTM.
 3. Never fight other commits: Ultralytics Actions pushes auto-format and header commits, and multiple users may work on the same PR. `git pull --rebase` before pushing; never force-push, reset, or revert commits you did not author.
 4. After the PR merges, clean up: remove local worktrees and branches for it, then `git checkout main && git pull`.
 


### PR DESCRIPTION
Names the Codex CLI (`codex exec`, one fresh cold run per round) as the adversarial reviewer in PR Workflow step 2, so agents follow the same review tooling used to validate the original AGENTS.md PRs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated PR review guidance to explicitly require fresh Codex CLI adversarial review runs for each iteration 🛠️

### 📊 Key Changes
- Clarified that independent adversarial reviews should be run using the Codex CLI.
- Specifies one fresh `codex exec` run per review round to ensure clean context.
- Keeps the existing workflow of fixing issues, pushing updates, and repeating until a fresh review reports LGTM ✅

### 🎯 Purpose & Impact
- Improves consistency in the PR review process by standardizing the review tool and workflow.
- Helps catch bugs, regressions, and principle violations more reliably through clean, independent review passes 🔍
- Reduces ambiguity for contributors working in `ultralytics/template-rust`, making review expectations clearer and easier to follow.