### PR TITLE
Harden release workflow: main-only, gate manual dispatch, clobber SBOM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/template-rust'
+    if: github.repository == 'ultralytics/template-rust' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -81,7 +81,7 @@ jobs:
           if increment == "True":
             print("Ready to publish new version to crates.io ✅.")
       - name: Tag and Release
-        if: steps.check_version.outputs.increment == 'True'
+        if: steps.check_version.outputs.increment == 'True' && (github.event_name == 'push' || inputs.publish == true)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT_TAG: ${{ steps.check_version.outputs.current_tag }}
@@ -97,7 +97,7 @@ jobs:
 
   build:
     needs: check
-    if: needs.check.outputs.increment == 'True'
+    if: needs.check.outputs.increment == 'True' && (github.event_name == 'push' || inputs.publish == true)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -113,7 +113,7 @@ jobs:
 
   publish:
     needs: [check, build]
-    if: needs.check.outputs.increment == 'True'
+    if: needs.check.outputs.increment == 'True' && (github.event_name == 'push' || inputs.publish == true)
     runs-on: ubuntu-latest
     environment:
       name: Release - crates.io
@@ -130,7 +130,7 @@ jobs:
 
   sbom:
     needs: [check, build, publish]
-    if: needs.check.outputs.increment == 'True'
+    if: needs.check.outputs.increment == 'True' && (github.event_name == 'push' || inputs.publish == true)
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -145,6 +145,6 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
           path: .
-      - run: gh release upload ${{ needs.check.outputs.current_tag }} sbom.spdx.json
+      - run: gh release upload ${{ needs.check.outputs.current_tag }} sbom.spdx.json --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🛠️ Summary

Brings the crates.io release workflow up to the hardened baseline already used in [ultralytics/inference](https://github.com/ultralytics/inference/blob/main/.github/workflows/publish.yml):

1. **Main-only trigger** — adds `github.ref == 'refs/heads/main'` to the `check` job so a `workflow_dispatch` from a feature branch cannot tag/release a non-main commit.
2. **Manual dispatch now respects the `publish` input** — the `publish` boolean input was defined but unused, so any manual dispatch ran the full tag/build/publish/sbom pipeline regardless. The jobs now gate on `(github.event_name == 'push' || inputs.publish == true)`, matching inference.
3. **`--clobber` on the SBOM upload** so a re-run can overwrite an existing asset instead of failing.

## 🧪 Testing

- YAML validated. Push-to-main behavior is unchanged; the only behavior change is that a manual dispatch with `publish` unchecked no longer tags/publishes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the Rust template release workflow to publish only from `main` and avoid accidental releases, while making SBOM uploads safer and repeatable 🚀

### 📊 Key Changes
- Restricts the release check job to run only in the `ultralytics/template-rust` repository on the `main` branch ✅
- Adds stricter conditions so tagging, building, publishing to crates.io, and SBOM generation only happen on:
  - `push` events
  - manual workflow runs with `publish` enabled
- Prevents release steps from running during non-publishing workflow events, reducing accidental release risk 🔒
- Updates SBOM upload to use `--clobber`, allowing an existing SBOM file on a GitHub Release to be replaced cleanly ♻️

### 🎯 Purpose & Impact
- Reduces the chance of unintended crates.io publishes from branches, forks, or non-release workflow triggers 🛡️
- Makes the release process more predictable and controlled for maintainers 🧰
- Improves reliability when regenerating or re-uploading SBOM files for existing releases 📦
- Helps keep published Rust crates and release artifacts consistent, secure, and easier to maintain ✨