### PR TITLE
Bump astral-sh/setup-uv from v8.2.0 to v8.3.0 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
       - name: Install ultralytics-actions
         run: uv pip install --system --no-cache ultralytics-actions
       - name: Fetch tags


### PR DESCRIPTION
Bump astral-sh/setup-uv from v8.2.0 to v8.3.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the GitHub publish workflow to use the latest `astral-sh/setup-uv` action version for improved CI reliability ⚙️

### 📊 Key Changes
- Bumped `astral-sh/setup-uv` from `v8.2.0` to `v8.3.0` in `.github/workflows/publish.yml` 🚀
- Keeps the action pinned to a specific commit SHA for better security and reproducibility 🔒
- No changes to Rust template source code or package behavior 📦

### 🎯 Purpose & Impact
- Improves the publishing workflow by adopting the latest `uv` setup action updates ✅
- Helps maintain CI/CD stability and compatibility with current tooling 🛠️
- Should be transparent to users, with no expected changes to how the Rust template is used 🙂