### PR TITLE
Bump taiki-e/install-action from v2.82.8 to v2.82.9 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
+        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.8 to v2.82.9 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the CI workflow dependency for installing `cargo-llvm-cov` to the latest pinned patch version 🔧

### 📊 Key Changes
- Bumped `taiki-e/install-action` from `v2.82.8` to `v2.82.9` in `.github/workflows/ci.yml` 🚀
- Keeps the GitHub Actions workflow pinned to a specific commit for reproducibility and supply-chain safety 🔒
- No Rust source code, tests, or project behavior were changed ✅

### 🎯 Purpose & Impact
- Improves CI maintenance by staying current with upstream GitHub Action updates 🛠️
- May include minor fixes or reliability improvements for installing `cargo-llvm-cov` 📈
- Should have no direct impact on users of the Rust template, aside from potentially more stable code coverage checks in CI ✨