### PR TITLE
Bump taiki-e/install-action from v2.82.9 to v2.82.10 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.9 to v2.82.10 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the GitHub Actions dependency for installing `cargo-llvm-cov` to the latest patch version 🔧

### 📊 Key Changes
- Bumped `taiki-e/install-action` from `v2.82.9` to `v2.82.10` in the CI workflow.
- Updated the pinned commit SHA for improved supply-chain consistency and reproducibility.
- No changes to Rust source code, tests, or project functionality.

### 🎯 Purpose & Impact
- Keeps CI tooling up to date with the latest fixes and improvements 🚀
- Helps maintain reliable code coverage setup using `cargo-llvm-cov`.
- Low risk for users, with impact limited to GitHub Actions CI behavior.