### PR TITLE
Bump astral-sh/setup-uv from v8.3.0 to v8.3.1 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+      - uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
       - name: Install ultralytics-actions
         run: uv pip install --system --no-cache ultralytics-actions
       - name: Fetch tags


### PR DESCRIPTION
Bump astral-sh/setup-uv from v8.3.0 to v8.3.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the GitHub Actions workflow dependency for `setup-uv` to the latest pinned patch version, improving CI reliability and maintenance. 🔧

### 📊 Key Changes
- Updated `astral-sh/setup-uv` in `.github/workflows/publish.yml` from pinned version `v8.3.0` to `v8.3.1`. 🚀
- Keeps the action pinned to a specific commit hash for safer and more reproducible workflow runs. 🔒

### 🎯 Purpose & Impact
- Improves the publishing workflow with the latest patch fixes from `setup-uv`. ✅
- Helps maintain secure, stable, and predictable CI/CD behavior for the Rust template repository. 🛠️
- No user-facing API or template functionality changes are expected. 📦