### PR TITLE
Bump taiki-e/install-action from v2.82.10 to v2.82.11 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        uses: taiki-e/install-action@5ebac0d9522d786674368e47e92963ba13f2c376 # v2.82.11
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.82.10 to v2.82.11 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the CI workflow to use a newer pinned version of the `cargo-llvm-cov` installation action. 🔧

### 📊 Key Changes

- Upgraded `taiki-e/install-action` from **v2.82.10** to **v2.82.11**.
- Kept the action pinned to a specific commit for reproducible and secure CI runs.
- No changes were made to Rust source code or project functionality.

### 🎯 Purpose & Impact

- ✅ Ensures CI uses the latest maintenance update for installing `cargo-llvm-cov`.
- 🛡️ Preserves reliable, repeatable code coverage workflows through commit pinning.
- 🚀 Users should see no direct runtime impact; this primarily improves development and automated testing infrastructure.