### PR TITLE
Bump astral-sh/setup-uv from v8.3.1 to v8.3.2 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Install ultralytics-actions
         run: uv pip install --system --no-cache ultralytics-actions
       - name: Fetch tags


### PR DESCRIPTION
Bump astral-sh/setup-uv from v8.3.1 to v8.3.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the publishing workflow to use `setup-uv` v8.3.2 for improved dependency management. ⚙️

### 📊 Key Changes

- Upgraded the `astral-sh/setup-uv` GitHub Action from v8.3.1 to v8.3.2.
- Updated the action to a new pinned commit for reproducible workflow runs.

### 🎯 Purpose & Impact

- ✅ Keeps the publishing pipeline aligned with the latest compatible `uv` setup action.
- 🔒 Maintains secure, deterministic CI/CD execution through commit pinning.
- 🚀 Provides maintenance and potential reliability improvements without changing project behavior.