### PR TITLE
Make Codecov upload best effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,10 @@ jobs:
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
           flags: template_coverage


### PR DESCRIPTION
## Summary\n- make the Codecov upload step non-blocking\n- keep existing coverage file, token, and flags settings\n\n## Validation\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves CI reliability by making Codecov coverage upload failures non-blocking 🚀

### 📊 Key Changes
- Added `continue-on-error: true` to the Codecov upload step ✅
- Set `fail_ci_if_error: false` in the Codecov action configuration 🛠️
- Keeps coverage generation unchanged while relaxing failure behavior for the upload step 📈

### 🎯 Purpose & Impact
- Prevents temporary Codecov outages, token issues, or network problems from failing otherwise healthy CI runs 🌐
- Improves developer experience by reducing false-negative build failures 🧑‍💻
- Maintains coverage reporting when available, without making it a required gate for PR success ✅