### PR TITLE
Bump taiki-e/install-action from v2.83.0 to v2.83.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2.83.0
+        uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2.83.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.83.0 to v2.83.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the GitHub Actions dependency used to install `cargo-llvm-cov` for Rust CI.

### 📊 Key Changes

- Upgrades `taiki-e/install-action` from v2.83.0 to v2.83.1.
- Keeps the action pinned to a specific commit for reproducible CI runs.
- No changes to Rust source code, tests, or application behavior.

### 🎯 Purpose & Impact

- ✅ Uses the latest patch release of the installation action.
- 🔒 Maintains secure and deterministic workflow execution through commit pinning.
- 🧪 Helps ensure code coverage checks continue running reliably in CI.
- 👤 No direct impact on end users or the template’s runtime functionality.