### PR TITLE
Bump taiki-e/install-action from v2.83.1 to v2.83.2 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2.83.1
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.83.1 to v2.83.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the GitHub Actions dependency used to install `cargo-llvm-cov` for CI coverage checks. 🔧

### 📊 Key Changes

- Upgraded `taiki-e/install-action` from `v2.83.1` to `v2.83.2`.
- Kept the existing `cargo-llvm-cov` installation and coverage workflow unchanged.
- Pinned the workflow to the updated commit for reproducible CI runs.

### 🎯 Purpose & Impact

- Improves CI reliability and compatibility through the latest action patch release. ✅
- Maintains automated Rust code coverage reporting without changing developer workflows.
- Introduces minimal risk because the update only affects the action version used during CI.