### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: ultralytics/actions/setup-uv@main
       - name: Install ultralytics-actions
         run: uv pip install --system --no-cache ultralytics-actions
       - name: Fetch tags


### PR DESCRIPTION
## Summary
- replace all 1 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 1 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the publishing workflow to use Ultralytics’ centralized `setup-uv` GitHub Action. 🔧

### 📊 Key Changes

- Replaces the pinned `astral-sh/setup-uv` action with `ultralytics/actions/setup-uv@main`.
- Keeps the existing Python setup and `ultralytics-actions` installation unchanged.
- Applies the change specifically to the package publishing workflow.

### 🎯 Purpose & Impact

- 🧩 Aligns the repository with Ultralytics’ shared CI/CD tooling.
- 🚀 Simplifies maintenance by centralizing `uv` setup logic.
- ⚠️ Uses the `main` branch rather than a fixed commit, which may introduce future behavior changes automatically.