### PR TITLE
Bump taiki-e/install-action from v2.83.3 to v2.83.4 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.83.3 to v2.83.4 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the CI workflow to use a newer `cargo-llvm-cov` installation action. 🚀

### 📊 Key Changes

- Upgraded `taiki-e/install-action` from `v2.83.3` to `v2.83.4`.
- Kept the configured tool unchanged: `cargo-llvm-cov`.
- Updated the pinned commit for reproducible GitHub Actions builds.

### 🎯 Purpose & Impact

- 🔧 Ensures CI uses the latest patch release of the installation action.
- ✅ May include upstream fixes and maintenance improvements.
- 🧪 Keeps code coverage checks functioning consistently without changing project behavior or application code.