### PR TITLE
Queue publish workflow runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  queue: max
 
 jobs:
   check:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ on:
         type: boolean
         description: Publish to crates.io
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   check:
     if: github.repository == 'ultralytics/template-rust' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

- Serialize publish workflows with `queue: max`.
- Preserve up to 100 pending release runs instead of replacing older pending releases.
- Align release robustness with [ultralytics/ultralytics#25331](https://github.com/ultralytics/ultralytics/pull/25331) without changing the repository-specific publisher.

Deleted: nothing — GitHub owns workflow scheduling, so preserving pending release runs requires workflow-level concurrency configuration.

## Validation

- `git diff --check`
- GitHub's documented `concurrency.queue: max` syntax; local actionlint 1.7.12 predates this property

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds workflow concurrency control to prevent overlapping Rust package publish runs. ⚙️

### 📊 Key Changes

- Introduced a GitHub Actions concurrency group for the publish workflow.
- Configured queued execution so publish jobs run sequentially rather than concurrently.
- Limited the change to the `publish.yml` workflow.

### 🎯 Purpose & Impact

- Prevents multiple publish workflows from running at the same time. ✅
- Reduces the risk of conflicting or duplicate crates.io releases.
- Makes package publishing more predictable and reliable, especially when workflows are triggered close together.