### PR TITLE
Bump taiki-e/install-action from v2.84.0 to v2.84.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
+        uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd # v2.84.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.84.0 to v2.84.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the CI workflow to use a newer pinned version of the `cargo-llvm-cov` installation action. 🔧

### 📊 Key Changes

- Upgraded `taiki-e/install-action` from v2.84.0 to v2.84.1.
- Kept the action pinned to a specific commit for reproducible and secure CI runs.
- No changes were made to the Rust source code or project behavior.

### 🎯 Purpose & Impact

- ✅ Applies the latest patch-level improvements from the action.
- 🛡️ Maintains dependable and auditable GitHub Actions builds through commit pinning.
- 🚀 May improve coverage-tool installation reliability without affecting end users or runtime functionality.