### PR TITLE
Bump taiki-e/install-action from v2.84.1 to v2.85.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@c44f6b046f1c29ae5918b1e0bfdbb2f1813836fd # v2.84.1
+        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.84.1 to v2.85.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the CI workflow to use the latest `cargo-llvm-cov` installation action version. ⚙️

### 📊 Key Changes

- Upgraded `taiki-e/install-action` from **v2.84.1** to **v2.85.0** in `.github/workflows/ci.yml`.
- Kept the `cargo-llvm-cov` installation step unchanged aside from the action version.

### 🎯 Purpose & Impact

- 🔄 Keeps the Rust CI pipeline aligned with the latest supported tooling.
- ✅ May provide improved compatibility, fixes, or reliability when installing `cargo-llvm-cov`.
- 🧪 Helps maintain consistent code coverage checks without changing application code or test behavior.