### PR TITLE
Bump taiki-e/install-action from v2.85.0 to v2.85.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
+        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.85.0 to v2.85.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the CI workflow to use the latest pinned version of the `cargo-llvm-cov` installation action. 🔧

### 📊 Key Changes
- Upgraded `taiki-e/install-action` from v2.85.0 to v2.85.1.
- Kept the action pinned to a specific commit for reproducible and secure CI runs.
- No changes to application or library source code.

### 🎯 Purpose & Impact
- Ensures CI uses the latest patch release for installing `cargo-llvm-cov`. ✅
- May provide minor fixes or improvements in code coverage tooling.
- Maintains consistent, secure, and repeatable workflow execution for contributors. 🚀