### PR TITLE
Bump taiki-e/install-action from v2.85.1 to v2.85.2 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.85.1 to v2.85.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the GitHub Actions dependency used to install `cargo-llvm-cov` to version 2.85.2. 🔧

### 📊 Key Changes

- Upgraded `taiki-e/install-action` from v2.85.1 to v2.85.2 in the CI workflow.
- Kept the `cargo-llvm-cov` installation process unchanged.
- No application or library source code was modified.

### 🎯 Purpose & Impact

- ✅ Keeps the CI pipeline aligned with the latest patch release of the installation action.
- 🛡️ May include upstream bug fixes, security improvements, or compatibility updates.
- 🚀 Maintains reliable code coverage checks without changing developer workflows.