### PR TITLE
Bump taiki-e/install-action from v2.85.2 to v2.85.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.85.2 to v2.85.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the GitHub Actions dependency used to install `cargo-llvm-cov` for Rust CI coverage checks. 🔧

### 📊 Key Changes

- Upgrades `taiki-e/install-action` from **v2.85.2** to **v2.85.3**.
- Keeps the `cargo-llvm-cov` installation step unchanged while refreshing its pinned action revision.
- No application code or runtime behavior is modified.

### 🎯 Purpose & Impact

- ✅ Incorporates the latest maintenance updates and fixes from the installation action.
- 📈 Helps keep CI coverage workflows reliable and up to date.
- 🚀 Has minimal impact on users because the change only affects automated development and testing workflows.