### PR TITLE
Bump taiki-e/install-action from v2.85.3 to v2.85.4 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.85.3 to v2.85.4 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the GitHub Actions dependency used to install `cargo-llvm-cov` to its latest pinned release. 🔧

### 📊 Key Changes
- Updated `taiki-e/install-action` from **v2.85.3** to **v2.85.4**.
- Kept the action pinned to a specific commit for reproducible and secure CI runs.
- No changes to Rust source code, tests, or application behavior.

### 🎯 Purpose & Impact
- ✅ Ensures CI uses the latest maintenance updates from the installation action.
- 🔒 Preserves dependable, version-controlled workflow execution.
- 📈 May improve coverage-tool installation reliability without affecting end users.