### PR TITLE
Bump taiki-e/install-action from v2.85.4 to v2.85.5 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.85.4 to v2.85.5 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the GitHub Actions installer to the latest `cargo-llvm-cov` installation action release. 🔧

### 📊 Key Changes

- Upgraded `taiki-e/install-action` from `v2.85.4` to `v2.85.5`.
- No changes were made to Rust source code, tests, or application behavior.
- The CI workflow continues using `cargo-llvm-cov` for code coverage reporting.

### 🎯 Purpose & Impact

- Keeps the CI pipeline aligned with the latest action patch release. ✅
- May include upstream maintenance, bug fixes, or security improvements.
- Should have no direct impact on end users, while improving CI reliability and maintainability. 🚀