### PR TITLE
Bump taiki-e/install-action from v2.85.5 to v2.85.7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.85.5 to v2.85.7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the CI workflow to install a newer `cargo-llvm-cov` action version. 🔧

### 📊 Key Changes

- Upgraded `taiki-e/install-action` from **v2.85.5** to **v2.85.7**.
- Kept the `cargo-llvm-cov` installation step unchanged apart from the action revision.

### 🎯 Purpose & Impact

- ✅ Keeps CI dependencies current with a newer action release.
- 🛡️ May include upstream fixes and security or compatibility improvements.
- 🚀 Helps maintain reliable code coverage checks without changing application behavior.