### PR TITLE
Add Slack notify job to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,3 +152,37 @@ jobs:
       - run: gh release upload ${{ needs.check.outputs.current_tag }} sbom.spdx.json --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify:
+    needs: [check, build, publish, sbom]
+    if: always() && needs.check.outputs.increment == 'True' && (github.event_name == 'push' || inputs.publish == true)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Get release title
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.check.outputs.current_tag }}
+        run: |
+          TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          TITLE=$(printf '%s' "$TITLE" | sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g")
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+      - name: Notify Success
+        if: needs.build.result == 'success' && needs.publish.result == 'success' && needs.sbom.result == 'success'
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
+          payload: |
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
+      - name: Notify Failure
+        if: needs.build.result != 'success' || needs.publish.result != 'success' || needs.sbom.result != 'success'
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
+          payload: |
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ❌ `${{ github.repository }}` ${{ needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"


### PR DESCRIPTION
## Summary

The publish workflow ended at `sbom` with no Slack notification — the only publish workflow across org repos without one. Adds the org-standard `notify` job (matching `ultralytics/inference` and `ultralytics/template`): release-title lookup via `gh release view` with PR-linked numbers, compact `<!subteam^S082BPCRAJ3>` success/failure payloads to `SLACK_WEBHOOK_URL_YOLO`, success gated on build + publish + sbom all passing, and the same push-or-dispatch gating as the other jobs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds Slack notifications to the release workflow for successful and failed publish operations. 📣

### 📊 Key Changes

- Introduces a new `notify` job that runs after release checks, builds, publishing, and SBOM generation.
- Sends a Slack success notification when all release stages complete successfully. ✅
- Sends a Slack failure notification if the build, publish, or SBOM stages fail. ❌
- Includes the repository, release tag, workflow run, and release links in Slack messages.
- Retrieves the release title and converts pull request references into clickable GitHub links.
- Uses the pinned `slackapi/slack-github-action` and `SLACK_WEBHOOK_URL_YOLO` secret.

### 🎯 Purpose & Impact

- Improves visibility into automated release outcomes without requiring developers to monitor GitHub Actions manually.
- Enables faster response to failed builds, publishing issues, or SBOM generation problems.
- Makes successful releases easier to discover through direct Slack links to the release and workflow run.
- Notifications only run for version increments triggered by pushes or explicitly requested publishes, reducing unnecessary alerts.