### PR TITLE
Bump taiki-e/install-action from v2.85.10 to v2.85.11 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.85.10 to v2.85.11 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the CI workflow’s `taiki-e/install-action` dependency from v2.85.10 to v2.85.11 to install `cargo-llvm-cov`.

### 📊 Key Changes
- Replaced the v2.85.10 commit reference with the v2.85.11 commit reference in `.github/workflows/ci.yml`.
- Kept the workflow configured to install the `cargo-llvm-cov` tool.

### 🎯 Purpose & Impact
- GitHub Actions CI now uses `taiki-e/install-action` v2.85.11 when installing `cargo-llvm-cov`.
- No other workflow behavior is changed.