### PR TITLE
Bump taiki-e/install-action from v2.85.12 to v2.85.13 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.85.12 to v2.85.13 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the CI workflow to use `taiki-e/install-action` v2.85.13 when installing `cargo-llvm-cov`.

### 📊 Key Changes

- Replaced the pinned `taiki-e/install-action` v2.85.12 commit with the v2.85.13 commit.
- Kept the workflow configured to install `cargo-llvm-cov`.
- Changed only the action reference in `.github/workflows/ci.yml`.

### 🎯 Purpose & Impact

- CI now uses the updated `taiki-e/install-action` release for `cargo-llvm-cov` installation.
- No user-facing change.