### PR TITLE
Tailor bug report components to the Rust crate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -28,16 +28,10 @@ body:
         Please select the component where you found the bug.
       multiple: true
       options:
-        - "Install"
-        - "Setup"
-        - "Configuration"
+        - "Install or build"
         - "CLI"
-        - "API"
-        - "Training"
-        - "Validation"
-        - "Prediction"
-        - "Export"
-        - "Integration"
+        - "Library API"
+        - "Configuration"
         - "Documentation"
         - "Other"
     validations:


### PR DESCRIPTION
Replaces the Python-flavoured component dropdown (Training/Validation/Prediction/Export/Integration) inherited from the Python template with components that exist in this crate: install or build, CLI, library API, configuration, documentation. The Environment and Minimal Reproducible Example fields were already Rust-specific.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the Rust crate bug report template to replace Python-specific component options with Rust-relevant areas for more accurate issue categorization.

### 📊 Key Changes
- Replaced “Install” and “Setup” with “Install or build”.
- Replaced “API” with “Library API”.
- Removed the Python-specific “Training”, “Validation”, “Prediction”, “Export”, and “Integration” options.
- Kept the Rust-relevant “CLI”, “Configuration”, “Documentation”, and “Other” options.

### 🎯 Purpose & Impact
- Bug reports now let users select components that correspond to the Rust crate’s installation, CLI, library API, configuration, and documentation workflows.