### PR TITLE
Bump taiki-e/install-action from v2.85.13 to v2.86.1 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.85.13 to v2.86.1 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the CI workflow’s `taiki-e/install-action` reference from v2.85.13 to v2.86.1 for installing `cargo-llvm-cov`.

### 📊 Key Changes
- Changed the pinned `taiki-e/install-action` commit in `.github/workflows/ci.yml`.
- Updated the version comment from `v2.85.13` to `v2.86.1`.
- Kept the workflow configured to install `cargo-llvm-cov`.

### 🎯 Purpose & Impact
- CI now uses `taiki-e/install-action` v2.86.1 when installing `cargo-llvm-cov`.
- No other workflow behavior is changed.