### PR TITLE
Bump taiki-e/install-action from v2.86.1 to v2.86.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
+        uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
Bump taiki-e/install-action from v2.86.1 to v2.86.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the CI workflow’s `taiki-e/install-action` reference from v2.86.1 to v2.86.3 to install `cargo-llvm-cov`.

### 📊 Key Changes
- Updated the pinned `taiki-e/install-action` commit in `.github/workflows/ci.yml`.
- Changed the associated release comment from `v2.86.1` to `v2.86.3`.
- Kept the workflow tool configuration unchanged with `tool: cargo-llvm-cov`.

### 🎯 Purpose & Impact
- CI now uses `taiki-e/install-action` v2.86.3 when installing `cargo-llvm-cov`.
- No other workflow steps or repository behavior were changed.