### PR TITLE
Install cargo-llvm-cov directly with Cargo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@6cd13508893c0e7eab5f273c2575d3859bd7229a # v2.86.6
-        with:
-          tool: cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
 
       - name: Coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --locked
+        run: cargo install cargo-llvm-cov --locked --force
 
       - name: Coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info


### PR DESCRIPTION
## Summary

- replace taiki-e/install-action with cargo install for cargo-llvm-cov
- keep the crate published lockfile authoritative with --locked
- resolve the latest published cargo-llvm-cov release at CI runtime

## Why

taiki-e/install-action is a shared installer whose releases track every supported tool, not only cargo-llvm-cov. It published 21 releases from July 24 through August 23, 2026, but only one changed cargo-llvm-cov. The organization-wide action updater consequently opened 18 install-action PRs in this repository during that period, mostly for unrelated tool manifest changes.

Installing the crate directly removes that noisy intermediary and uses the standard Cargo distribution path. This intentionally trades reviewed installer-action bumps for automatic resolution of the latest cargo-llvm-cov release when CI runs. The --force option is required because hosted runner images can contain binaries outside the Cargo install registry; Cargo otherwise refuses to replace them.

## Validation

- git diff --check
- npx prettier@3.8.5 --print-width 120 --check .github/workflows/ci.yml
- cargo install cargo-llvm-cov --locked --force
- cargo llvm-cov --version: 0.9.0

Cold local installation took approximately 26 seconds.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated CI to install `cargo-llvm-cov` directly with Cargo using the repository’s locked dependency versions, avoiding the shared installer action.

### 📊 Key Changes

- Replaced `taiki-e/install-action` with `cargo install cargo-llvm-cov --locked --force`.
- Uses Cargo’s published lockfile to resolve the latest `cargo-llvm-cov` release at CI runtime.
- Retains the existing `cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info` coverage command.

### 🎯 Purpose & Impact

- CI no longer depends on `taiki-e/install-action` updates to install `cargo-llvm-cov`.
- The `--force` option allows Cargo to replace preinstalled binaries on hosted runners.
- The coverage workflow continues to run through `cargo llvm-cov`; no other user-facing behavior changes.