### PR TITLE
Accept normalized CLA signature comments

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   CLA:
-    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA'))
+    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || contains(github.event.comment.body, 'I have read the CLA Document and I sign the CLA')))
     concurrency:
       group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Valid CLA signature comments with trailing whitespace or surrounding Markdown currently never reach the normalized action matcher because the workflow gate requires exact equality.

This makes only the signature gate permissive. The `recheck` command remains exact, and the action still decides whether a single normalized line is a valid signature, so quoted or instructional text does not sign the CLA.

Related matcher fix: ultralytics/actions#894

Validation:
- `actionlint .github/workflows/cla.yml`
- `npx prettier@3.8.5 --check .github/workflows/cla.yml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the CLA workflow to pass comment bodies containing the standard signature text, allowing normalized signature matching to process surrounding whitespace or Markdown.

### 📊 Key Changes

- Replaced exact equality for CLA signature comments with a `contains()` check in `.github/workflows/cla.yml`.
- Kept the `recheck` command under exact matching.
- Left final signature validation to the action’s normalized single-line matcher, so surrounding quoted or instructional text is not treated as a signature by this workflow change.

### 🎯 Purpose & Impact

- CLA comments with trailing whitespace or surrounding Markdown can now reach the normalized matcher instead of being rejected by the workflow gate.
- The workflow’s `recheck` behavior remains unchanged.