### PR TITLE
Bump anchore/sbom-action from v0.24.0 to v0.24.2 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,7 +144,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Generate Cargo.lock for SBOM
         run: cargo generate-lockfile
-      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      - uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
           format: spdx-json
           output-file: sbom.spdx.json


### PR DESCRIPTION
Bump anchore/sbom-action from v0.24.0 to v0.24.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the publish workflow’s Anchore SBOM action from v0.24.0 to v0.24.2 to use the newer pinned release.

### 📊 Key Changes
- Replaced the `anchore/sbom-action` v0.24.0 commit reference with the v0.24.2 commit reference in `.github/workflows/publish.yml`.
- Kept SBOM generation configured for `spdx-json` output at `sbom.spdx.json`.

### 🎯 Purpose & Impact
- The publish workflow now generates SBOMs using `anchore/sbom-action` v0.24.2.
- No other workflow behavior was changed.